### PR TITLE
Removed post.Tags assignment on update

### DIFF
--- a/APIs/CategoryAPI.cs
+++ b/APIs/CategoryAPI.cs
@@ -7,7 +7,7 @@ namespace Rare.APIs
             // get all categories
             app.MapGet("/categories", (RareDbContext db) =>
             {
-                var allCategories = db.Categories.ToList();
+                var allCategories = db.Categories.OrderBy(c => c.Label).ToList();
                 if (allCategories.Any())
                 {
                     return Results.Ok(allCategories);

--- a/APIs/PostAPI.cs
+++ b/APIs/PostAPI.cs
@@ -70,7 +70,9 @@ namespace Rare.APIs
                         tag.Id,
                         tag.Label
                     }),
-                    Comments = post.Comments.Select(comment => new
+                    Comments = post.Comments
+                        .OrderBy(c => c.CreatedOn)
+                        .Select(comment => new
                     {
                         comment.Id,
                         comment.Content,

--- a/APIs/PostAPI.cs
+++ b/APIs/PostAPI.cs
@@ -136,7 +136,6 @@ namespace Rare.APIs
                 postToUpdate.Content = post.Content;
                 postToUpdate.ImageURL = post.ImageURL;
                 postToUpdate.CategoryId = post.CategoryId;
-                postToUpdate.Tags = post.Tags;
                 postToUpdate.AuthorId = post.AuthorId;
 
                 db.SaveChanges();

--- a/APIs/TagAPI.cs
+++ b/APIs/TagAPI.cs
@@ -12,7 +12,8 @@ namespace Rare.APIs
                 {
                     t.Id,
                     t.Label
-                });
+                })
+                .OrderBy(t => t.Label);
             });
 
             app.MapPost("/tags", (RareDbContext db, Tag addTag) =>


### PR DESCRIPTION
Removed postToUpdate.Tags = post.Tags assignment to avoid attempted duplication of postTags on post update (broke API execution)

Tags and Categories return alphabetically