### PR TITLE
Check sub hs

### DIFF
--- a/APIs/SubscriptionAPI.cs
+++ b/APIs/SubscriptionAPI.cs
@@ -102,6 +102,32 @@ namespace Rare.APIs
                 db.SaveChanges();
                 return Results.Ok($"Subscription ended on {subscription.EndedOn}");
             });
+
+            // Check User Subscription Status
+            app.MapGet("subscription/{userId}/{authorId}", (RareDbContext db, int userId, int authorId) =>
+            {
+                bool canSubscribe = true;
+
+                if (userId == authorId)
+                {
+                    canSubscribe = false;
+                    return Results.Ok(canSubscribe);
+                }
+
+                // Find User's active subscription to author.
+                var subscription = db.Subscriptions.SingleOrDefault(s => s.AuthorId == authorId
+                                                                    && s.FollowerId == userId
+                                                                    && s.EndedOn == null);
+
+                // If an active subscription is found, a new subscription cannot be made.
+                if (subscription != null)
+                {
+                    canSubscribe = false;
+                    return Results.Ok(canSubscribe);
+                }
+
+                return Results.Ok(canSubscribe);
+            });
         }
     }
 }

--- a/APIs/SubscriptionAPI.cs
+++ b/APIs/SubscriptionAPI.cs
@@ -115,6 +115,19 @@ namespace Rare.APIs
                     return Results.Ok(canSubscribe);
                 }
 
+                var userExists = db.Users.SingleOrDefault(u => u.Id == userId);
+                var authorExists = db.Users.SingleOrDefault(u => u.Id == authorId);
+
+                if (userExists == null)
+                {
+                    return Results.NotFound("The userId does not exist");
+                }
+
+                if (authorExists == null)
+                {
+                    return Results.NotFound("The authorId does not exist");
+                }
+
                 // Find User's active subscription to author.
                 var subscription = db.Subscriptions.SingleOrDefault(s => s.AuthorId == authorId
                                                                     && s.FollowerId == userId


### PR DESCRIPTION
- Added API call to check if user can subscribe to author.
- Returns false (cannot subscribe) if user tries to subscribe to themselves or to an author they are already actively subscribed too.
- Error handling for user and author ids that do not exist.