### PR TITLE
Exception handling update

### DIFF
--- a/APIs/PostAPI.cs
+++ b/APIs/PostAPI.cs
@@ -190,16 +190,7 @@ namespace Rare.APIs
                 }
                 else
                 {
-                    bool categoryExist = db.Categories.Any(c => c.Id == categoryId);
-                    if (categoryExist)
-                    {
-                        return Results.Ok($"There are no post for this category with an id of {categoryId}");
-
-                    }
-                    else
-                    {
-                        return Results.NotFound($"There is no category with an id of {categoryId}");
-                    }
+                    return Results.Ok(new List<object>());
                 }
             });
 


### PR DESCRIPTION
## Detailed Description
Changed exception handling for the `get posts by category id` endpoint.

## Related Issues
- #14 

## How to Test
Test the category filter on the frontend or test the endpoint in Swagger.

## Motivation and Context
This change is required because the frontend was throwing an error when attempting to get posts for a category for which no posts exist. The error is due to the endpoint returning a string rather than an array when no posts in a selected category exist. This change returns an empty array in this instance and allows the logic to be handled on the frontend, allowing the category filter to function properly.

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation