### PR TITLE
Updated search posts handler function

### DIFF
--- a/APIs/PostAPI.cs
+++ b/APIs/PostAPI.cs
@@ -207,28 +207,27 @@ namespace Rare.APIs
                         post.PublicationDate.ToString().Contains(searchValue) ||
                         post.Tags.Any(tag => tag.Label.ToLower().Contains(searchValue.ToLower()))
                     )
-                     .Select(post => new
-                     {
-                         post.Id,
-                         post.Title,
-                         post.Content,
-                         post.Category,
-                         post.ImageURL,
-                         post.PublicationDate,
-                         Author = new
-                         {
-                             post.Author.Id,
-                             post.Author.FirstName,
-                             post.Author.LastName,
-                             post.Author.UserName,
-                             post.Author.ImageURL
-                         }
-                     })
+                    .Select(post => new
+                    {
+                        post.Id,
+                        post.Title,
+                        post.Content,
+                        post.Category,
+                        post.ImageURL,
+                        post.PublicationDate,
+                        Author = new
+                        {
+                            post.Author.Id,
+                            post.Author.FirstName,
+                            post.Author.LastName,
+                            post.Author.UserName,
+                            post.Author.ImageURL
+                        }
+                    })
                     .ToList();
 
-                return searchResults.Any() ? Results.Ok(searchResults) : Results.StatusCode(204);
+                return Results.Ok(searchResults);
             });
-                   
         }
     }
 }


### PR DESCRIPTION
## Detailed Description
Changed exception handling for the `search posts` endpoint.

## Related Issues
- #12 

## How to Test
Test the search bar on the frontend or test the endpoint in Swagger.

## Motivation and Context
This change is required because the frontend was throwing an error when attempting to search for something that doesn't exist. The endpoint will now return an empty array instead.

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation